### PR TITLE
Fix: `h3_to_parent(0)` correctly creates column `h3_00`

### DIFF
--- a/h3pandas/h3pandas.py
+++ b/h3pandas/h3pandas.py
@@ -324,7 +324,11 @@ class H3Accessor:
         881e2659c3fffff    1  851e265bfffffff
         """
         # TODO: Test `h3_parent` case
-        column = self._format_resolution(resolution) if resolution else "h3_parent"
+        column = (
+            self._format_resolution(resolution)
+            if resolution is not None
+            else "h3_parent"
+        )
         return self._apply_index_assign(
             wrapped_partial(h3.h3_to_parent, res=resolution), column
         )

--- a/tests/test_h3pandas.py
+++ b/tests/test_h3pandas.py
@@ -159,6 +159,13 @@ class TestH3ToParent:
 
         pd.testing.assert_frame_equal(expected, result)
 
+    def test_h3_to_parent_level_0(self, h3_dataframe_with_values):
+        h3_parent = "801ffffffffffff"
+        result = h3_dataframe_with_values.h3.h3_to_parent(0)
+        expected = h3_dataframe_with_values.assign(h3_00=h3_parent)
+
+        pd.testing.assert_frame_equal(expected, result)
+
 
 class TestH3ToCenterChild:
     def test_h3_to_center_child(self, indexed_dataframe):

--- a/tests/test_h3pandas.py
+++ b/tests/test_h3pandas.py
@@ -145,10 +145,17 @@ class TestH3ToGeoBoundary:
 
 
 class TestH3ToParent:
-    def test_h3_to_parent(self, h3_dataframe_with_values):
+    def test_h3_to_parent_level_1(self, h3_dataframe_with_values):
         h3_parent = "811f3ffffffffff"
         result = h3_dataframe_with_values.h3.h3_to_parent(1)
         expected = h3_dataframe_with_values.assign(h3_01=h3_parent)
+
+        pd.testing.assert_frame_equal(expected, result)
+
+    def test_h3_to_direct_parent(self, h3_dataframe_with_values):
+        h3_parents = ["881f1d4817fffff", "881f1d4817fffff", "881f1d4811fffff"]
+        result = h3_dataframe_with_values.h3.h3_to_parent()
+        expected = h3_dataframe_with_values.assign(h3_parent=h3_parents)
 
         pd.testing.assert_frame_equal(expected, result)
 


### PR DESCRIPTION
# What this PR does
Fixes error described in #15 where `h3_to_parent(0)` would create column named `h3_parent` instead of `h3_00`.

# Closes
Closes #15 