### PR TITLE
Fix: k-ring smoothing does not fail if geometry is present + switch to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,10 @@ repos:
       - id: black
         language_version: python3
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.5
     hooks:
-      - id: flake8
-        language_version: python3
+      - id: ruff
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,19 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.10.0
     hooks:
       - id: black
         language_version: python3
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 6.1.0
     hooks:
       - id: flake8
         language_version: python3
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v1.16.0
+    rev: v2.2.6
     hooks:
       - id: codespell
+        args: ['--config', '.codespellrc']
         language_version: python3

--- a/h3pandas/h3pandas.py
+++ b/h3pandas/h3pandas.py
@@ -660,6 +660,9 @@ class H3Accessor:
         881e30973bfffff  0.714286
         881e30973dfffff  0.714286
         """
+        # Drop geometry if present
+        df = self._df.drop(columns=["geometry"], errors="ignore")
+
         if sum([weights is None, k is None]) != 1:
             raise ValueError("Exactly one of `k` and `weights` must be set.")
 
@@ -671,7 +674,7 @@ class H3Accessor:
         # Unweighted case
         if weights is None:
             result = pd.DataFrame(
-                self._df.h3.k_ring(k, explode=True)
+                df.h3.k_ring(k, explode=True)
                 .groupby("h3_k_ring")
                 .sum()
                 .divide((1 + 3 * k * (k + 1)))
@@ -695,10 +698,7 @@ class H3Accessor:
 
         result = (
             pd.concat(
-                [
-                    weighted_hex_ring(self._df, i, weights[i])
-                    for i in range(len(weights))
-                ]
+                [weighted_hex_ring(df, i, weights[i]) for i in range(len(weights))]
             )
             .groupby("h3_hex_ring")
             .sum()

--- a/tests/test_h3pandas.py
+++ b/tests/test_h3pandas.py
@@ -1,7 +1,7 @@
 from h3pandas import h3pandas  # noqa: F401
 from h3 import h3
 import pytest
-from shapely.geometry import Polygon, box
+from shapely.geometry import Polygon, box, Point
 import pandas as pd
 import geopandas as gpd
 from geopandas.testing import assert_geodataframe_equal
@@ -518,6 +518,12 @@ class TestKRingSmoothing:
         expected = set([1 / 4, 1 / 8])
         result = set(data.h3.k_ring_smoothing(weights=[2, 1])["val"])
         assert expected == result
+
+    def test_does_not_fail_if_geometry_present(self, h3_geodataframe_with_values):
+        h3_geodataframe_with_values["geometry"] = [Point(0, 0)] * len(
+            h3_geodataframe_with_values
+        )
+        h3_geodataframe_with_values.h3.k_ring_smoothing(1)
 
 
 class TestPolyfillResample:


### PR DESCRIPTION
# What this PR does
`k_ring_smoothing` started failing since geometry cannot be aggregated  with `sum`

Additionally, switch to ruff