### PR TITLE
feat: Update to H3 version 4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,11 +6,8 @@ dependencies:
   - shapely
   - geopandas>=0.9.*
   - pandas
+  - h3-py>=4
   # Notebooks
   - matplotlib
   # Pip
   - pip
-  - pip:
-    # Installing through pip to avoid segfault on Apple Silicon
-    # https://github.com/uber/h3-py/issues/313
-    - h3==3.7.6

--- a/h3pandas/util/decorator.py
+++ b/h3pandas/util/decorator.py
@@ -1,6 +1,5 @@
 from functools import wraps
 from typing import Callable, Iterator
-from h3 import H3CellError
 
 
 def catch_invalid_h3_address(f: Callable) -> Callable:
@@ -25,7 +24,7 @@ def catch_invalid_h3_address(f: Callable) -> Callable:
     def safe_f(*args, **kwargs):
         try:
             return f(*args, **kwargs)
-        except (TypeError, ValueError, H3CellError) as e:
+        except (TypeError, ValueError) as e:
             message = "H3 method raised an error. Is the H3 address correct?"
             message += f"\nCaller: {f.__name__}({_print_signature(*args, **kwargs)})"
             message += f"\nOriginal error: {repr(e)}"
@@ -47,6 +46,7 @@ def sequential_deduplication(func: Iterator[str]) -> Iterator[str]:
     -------
     Yields from f, but won't yield two items in a row that are the same.
     """
+
     def inner(*args):
         iterable = func(*args)
         last = None
@@ -54,6 +54,7 @@ def sequential_deduplication(func: Iterator[str]) -> Iterator[str]:
             if cell != last:
                 yield cell
             last = cell
+
     return inner
 
 

--- a/tests/util/test_decorator.py
+++ b/tests/util/test_decorator.py
@@ -1,4 +1,4 @@
-from h3 import h3
+import h3
 import pytest
 
 from h3pandas.util.decorator import catch_invalid_h3_address, sequential_deduplication
@@ -8,7 +8,7 @@ class TestCatchInvalidH3Address:
     def test_catch_invalid_h3_address(self):
         @catch_invalid_h3_address
         def safe_h3_to_parent(h3_address):
-            return h3.h3_to_parent(h3_address, 1)
+            return h3.cell_to_parent(h3_address, 1)
 
         with pytest.raises(ValueError):
             safe_h3_to_parent("a")  # Originally ValueError

--- a/tests/util/test_shapely.py
+++ b/tests/util/test_shapely.py
@@ -5,19 +5,19 @@ from h3pandas.util.shapely import polyfill, linetrace
 
 @pytest.fixture
 def polygon():
-    return Polygon([(48, 18), (49, 18), (49, 19), (48, 19)])
+    return Polygon([(18, 48), (18, 49), (19, 49), (19, 48)])
 
 
 @pytest.fixture
 def polygon_b():
-    return Polygon([(54, 11), (56, 11), (56, 12), (54, 12)])
+    return Polygon([(11, 54), (11, 56), (12, 56), (12, 54)])
 
 
 @pytest.fixture
 def polygon_with_hole():
     return Polygon(
-        [(48, 18), (49, 18), (49, 19), (48, 19)],
-        [[(48.4, 18.2), (48.8, 18.2), (48.8, 18.6), (48.4, 18.6)]],
+        [(18, 48), (19, 48), (19, 49), (18, 49)],
+        [[(18.2, 48.4), (18.6, 48.4), (18.6, 48.8), (18.2, 48.8)]],
     )
 
 
@@ -73,6 +73,6 @@ class TestLineTrace:
         assert expected == result
 
         # Lists not sets, repeated items are expected, just not in sequence
-        expected2 = ['82754ffffffffff', '827547fffffffff', '82754ffffffffff']
+        expected2 = ["82754ffffffffff", "827547fffffffff", "82754ffffffffff"]
         result2 = list(linetrace(multiline, 2))
         assert expected2 == result2


### PR DESCRIPTION
# What this PR does
Updates to `h3-py` API version 4

This keeps the current API of H3-Pandas. I did not want to create breaking changes for now. 

Can consider switching to an API more aligned with v4 in the future